### PR TITLE
[add] promises list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ coverage
 dist
 node_modules
 .DS_Store
+.idea
 npm-debug.log

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,14 @@ export { WAIT_FOR_ACTION, ERROR_ACTION };
 
 export default function() {
   const pendingActionList = [];
+  const promisesList = [];
+  const getPromisesList = () => promisesList;
 
   //eslint-disable-next-line
-  return store => next => action => {
+  const middleware = store => next => action => {
 
     for (let i = pendingActionList.length - 1; i >= 0; i--) {
-      let pendingActionInfo = pendingActionList[i];
+      const pendingActionInfo = pendingActionList[i];
       if (pendingActionInfo.isSuccessAction(action)) {
         pendingActionInfo.resolveCallback(action.payload || action.data || {});
       } else if (pendingActionInfo.isErrorAction(action)) {
@@ -52,10 +54,13 @@ export default function() {
     });
 
     pendingActionList.push(newPendingActionInfo);
+    promisesList.push(promise);
 
     next(action);
 
     return promise;
 
   };
+
+  return Object.assign(middleware, { getPromisesList });
 }


### PR DESCRIPTION
Hello there :)

We have a lot of async sagas that must be done before server rendering, therefore we need to store all promises and it seems annoying (too much `const promise = store.dispatch()`). We can see that better way to make a small middleware collecting such promises, but I’ve realized that we try to reinventing redux-wait-for-action. With this PR  redux-wait-for-action will allow us for gathering promises resolving after [WAIT_FOR_ACTION] without annoying overhead code (like collecting promises from fetch at https://blog.chionlab.moe/2016/12/21/universal-react-app-reuse-effects-on-server-side/#更优雅地组织同构应用). 

configureStore.js:
```javascript
import <...>

export default function configureStore(initialState, helpersConfig) {

  const sagaMiddleware = createSagaMiddleware()
  const reduxWaitForMiddleware = createReduxWaitForMiddleware()

  <...>
  const store = createStore(rootReducer, initialState, enhancer)
  store.prerenderSagasDone = () => {
    const pending = reduxWaitForMiddleware.getPromisesList()
    return Promise.all(pending)
  }
  return store
}
```

handleServerRendering.js (Express middleware)
```javascript
  await store.prerenderSagasDone()
  const html = ReactDOM.renderToStaticMarkup(<Html {...data} />)
  res.status(route.status || 200)
  res.send(`<!doctype html>${html}`)
```

No any other changes. In the action creators all the same (just [WAIT_FOR_ACTION] and [ERROR_ACTION] properties adding to Flux Standard Action).