### PR TITLE
Remove .babelrc from repo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-	"presets": ["es2015", "stage-0"],
-	"plugins": []
-}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .DS_Store
 .idea
 npm-debug.log
+.babelrc


### PR DESCRIPTION
I've created an issue for this here:
https://github.com/Chion82/redux-wait-for-action/issues